### PR TITLE
GHC 9.4.3 Compiler Bug Workaround

### DIFF
--- a/src/Language/Haskell/To/Elm.hs
+++ b/src/Language/Haskell/To/Elm.hs
@@ -173,7 +173,7 @@ instance (DeriveParameterisedElmTypeDefinition (numParams + 1) (f (Parameter num
 
 instance (KnownNat numParams, SOP.HasDatatypeInfo a, SOP.All2 HasElmType (SOP.Code a)) => DeriveParameterisedElmTypeDefinition numParams (a :: Data.Kind.Type) where
   deriveParameterisedElmTypeDefinition options name =
-    case dataShape @a $ ConstraintFun constraintFun of
+    case dataShape @a Proxy $ ConstraintFun constraintFun of
       [(_cname, RecordConstructorShape fields)] ->
         Definition.Alias name numParams (bindTypeParameters $ Type.Record $ first fieldName <$> fields)
 
@@ -257,7 +257,7 @@ instance (HasElmType a, KnownNat numParams, SOP.HasDatatypeInfo a, SOP.All2 (Has
   deriveParameterisedElmDecoderDefinition options aesonOptions decoderName =
     Definition.Constant decoderName numParams parameterisedType $
       parameteriseBody $
-        case dataShape @a $ ConstraintFun constraintFun of
+        case dataShape @a Proxy $ ConstraintFun constraintFun of
           [(_cname, RecordConstructorShape fields)] ->
             decodeRecordFields fields $
             Expression.App "Json.Decode.succeed" $
@@ -515,7 +515,7 @@ instance (HasElmType a, KnownNat numParams, SOP.HasDatatypeInfo a, SOP.All2 (Has
     Definition.Constant encoderName numParams parameterisedType $
       parameteriseBody $
         Expression.Lam $ Bound.toScope $
-          case dataShape @a $ ConstraintFun constraintFun of
+          case dataShape @a Proxy $ ConstraintFun constraintFun of
             [(_cname, RecordConstructorShape fields)] ->
               Expression.App "Json.Encode.object" $
               encodedRecordFieldList fields $ pure $ Bound.B ()

--- a/src/Language/Haskell/To/Elm/DataShape.hs
+++ b/src/Language/Haskell/To/Elm/DataShape.hs
@@ -31,9 +31,10 @@ newtype ConstraintFun constraint a = ConstraintFun (forall t. Dict (constraint t
 dataShape
   :: forall typ constraint a
   . (All2 constraint (Code typ), HasDatatypeInfo typ)
-  => ConstraintFun constraint a
+  => Proxy typ 
+  -> ConstraintFun constraint a
   -> DataShape a
-dataShape f =
+dataShape _ f =
   constructorShapes @(Code typ) @constraint f $ constructorInfo $ datatypeInfo $ Proxy @typ
 
 constructorShapes


### PR DESCRIPTION
GHC 9.4.x came with a compiler bug that caused the type signature of `dataShape` in `Language.Haskell.To.Elm.DataShape` to trigger infinite looping in the constraint solver, making the module compile indefinitely even with `-fconstraint-solver-iterations=0` (no limit) passed to GHC.

This package not compiling was barring `supercede`'s migration to GHC 9.4.3; I tried to remove `dataShape` per Jappie's suggestion, but it was used in various other places within the package making it nontrivial and somewhat unpredictable to move forward with.

As such, I decided to fork the project and play around to see if I could fix this. I commented out the constraint which allowed it compile, and noticed the type variable `typ` only appeared in the constraint head, not the signature body. I suspected this was another case of the compiler getting confused because of a type variable not appearing in the signature body somewhere, so I added a redundant `Proxy typ` parameter to the signature body and propagated the change to all of `dataShape`'s use sites. In a stroke of fortune, the package compiled at last; without needing the constraint solver iteration flag.

This PR implements the aforementioned workaround for the compiler bug.

The compiler bug in question has allegedly been fixed in GHC 9.6.x, however `supercede` will not migrate to this version for the foreseeable future as far too many packages will break in the process as of right now. Thus, there is still value in using this workaround fork until whensoever we should decide to migrate to 9.6.x in the future.